### PR TITLE
fix: event list component receives specific href paths

### DIFF
--- a/src/components/EventList.tsx
+++ b/src/components/EventList.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import React from 'react';
 
 interface Item {
-    uid: string;
+    href: string;
     name: string;
     date: string;
 }
@@ -19,7 +19,7 @@ const EventList: React.FC<EventListProps> = ({ eventItems }) => {
                 eventItems.length ? (
                     <ul className="space-y-2">
                         {eventItems.map((item, index) => (
-                            <Link key={index} href={`/user/evaluations/fill?evaluation=${item.uid}`}>
+                            <Link key={index} href={item.href}>
                                 <li className="flex justify-between text-sm hover:text-primary transition-colors">
                                     <span className='block text-left'>{item.name}</span>
                                     <span className='block text-right'>{item.date}</span>

--- a/src/components/SpecialistDashboard.tsx
+++ b/src/components/SpecialistDashboard.tsx
@@ -17,11 +17,11 @@ const SpecialistDashboard: React.FC<DashboardProps> = ({ lastEvaluations, lastRe
     <div className="flex bg-background p-6 rounded-lg shadow-lg md:min-w-[600px]">
       <div className="flex-1 text-center">
         <h2 className="text-md font-medium mb-4">Últimas avaliações</h2>
-        <EventList eventItems={lastEvaluations}/>
+        <EventList eventItems={lastEvaluations.map(e => ({href: '/specialist/evaluations', ...e}))}/>
       </div>
       <div className="flex-1 text-center mx-6">
         <h2 className="text-md font-medium mb-4">Últimos resultados</h2>
-        <EventList eventItems={lastResults}/>
+        <EventList eventItems={lastResults.map(e => ({href: '/specialist/results', ...e}))}/>
       </div>
       <div className="flex-0 text-center">
         <h2 className="text-md font-medium mb-4">Nº Usuários</h2>

--- a/src/components/UserDashboard.tsx
+++ b/src/components/UserDashboard.tsx
@@ -17,11 +17,11 @@ const UserDashboard: React.FC<DashboardProps> = ({ pendingEvaluations, available
     <div className="flex bg-background p-6 rounded-lg shadow-lg md:min-w-[600px]">
       <div className="flex-1 text-center">
         <h2 className="text-md font-medium mb-4">Avaliações Pendentes</h2>
-        <EventList eventItems={pendingEvaluations}/>
+        <EventList eventItems={pendingEvaluations.map(e => ({href: `/user/evaluations/fill?evaluation=${e.uid}`, ...e}))}/>
       </div>
       <div className="flex-1 text-center mx-6">
         <h2 className="text-md font-medium mb-4">Resultados Disponíveis</h2>
-        <EventList eventItems={availableResults}/>
+        <EventList eventItems={availableResults.map(e => ({href: `/user/evaluations/fill?evaluation=${e.uid}`, ...e}))}/>
       </div>
     </div>
   );


### PR DESCRIPTION
this is due to the way accessing specific evalutions work completely different between users and specialists: users can access evalutions through a fixed URL path with the evalution id in the query strings; on the other hand, specialists need the evalution they mean to access to have been added to the session context beforehand, which a standard hyperlink alone is not capable of doing.