### PR TITLE
fix: formatar telefone usando value do input

### DIFF
--- a/src/components/form/EditSpecialistDataForm.tsx
+++ b/src/components/form/EditSpecialistDataForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ChangeEvent } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import {
@@ -164,8 +165,8 @@ const EditSpecialistDataForm = ({ data }: any) => {
                     <Input 
                     placeholder='(99) 99999-9999' 
                     {...field} 
-                    onChange={(value: string): void => {
-                      field.onChange(formatPhone(value))
+                    onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+                      field.onChange(formatPhone(e.target.value))
                     }} 
                     />
                   </FormControl>

--- a/src/components/form/EditUserDataForm.tsx
+++ b/src/components/form/EditUserDataForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ChangeEvent } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import {
@@ -259,8 +260,8 @@ const EditUserDataForm = ({ data }: any) => {
                                         <Input
                                             placeholder='(99) 99999-9999'
                                             {...field}
-                                            onChange={(value: string): void => {
-                                                field.onChange(formatPhone(value))
+                                            onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+                                                field.onChange(formatPhone(e.target.value))
                                             }}
                                         />
                                     </FormControl>

--- a/src/components/form/SignUpSpecialistForm.tsx
+++ b/src/components/form/SignUpSpecialistForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ChangeEvent } from 'react';
 import { useForm } from 'react-hook-form';
 import { useRouter } from 'next/navigation';
 import {
@@ -201,8 +202,8 @@ const SignUpForm = () => {
                     <Input 
                     placeholder='(99) 99999-9999' 
                     {...field} 
-                    onChange={(value: string): void => {
-                      field.onChange(formatPhone(value))
+                    onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+                       field.onChange(formatPhone(e.target.value))
                     }} 
                     />
                   </FormControl>

--- a/src/components/form/SignUpUserForm.tsx
+++ b/src/components/form/SignUpUserForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { ChangeEvent } from 'react';
 import { useForm } from 'react-hook-form';
 import {
   Form,
@@ -279,8 +280,8 @@ const SignUpForm = ({specialistId}) => {
                       <Input 
                       placeholder='(99) 99999-9999' 
                       {...field} 
-                      onChange={(value: any): void => {
-                        field.onChange(formatPhone(value))
+                      onChange={(e: ChangeEvent<HTMLInputElement>): void => {
+                        field.onChange(formatPhone(e.target.value))
                       }} 
                       />
                     </FormControl>


### PR DESCRIPTION
### **Problema**
Quando eu fui digitar o telefone, o app quebrava com `TypeError: value.replace is not a function` em `formatPhone`, porque o `onChange` passava o evento do input para uma função que espera `string`.

### **Solução**
Padronizar `onChange` para usar `e.target.value` antes de `formatPhone`.

### **Escopo**
Ajuste aplicado em todos os formulários com o mesmo padrão (cadastro e edição).

### **Validação**
Mantida a validação Zod existente para telefone; apenas remove o crash em tempo de digitação.

### **Testes manuais**
Cadastro - digitar telefone não quebra mais; submit continua validando.

**Antes:**

https://github.com/user-attachments/assets/457b9835-e8b9-410a-8e30-814cda1ff374

**Depois:**

https://github.com/user-attachments/assets/a3f4d747-e6d1-42fa-94e8-5775b3f83694

