### PR TITLE
feat: integra micro frontend do sus adaptado

### DIFF
--- a/src/app/(authenticated)/specialist/evaluations/results/answer/page.tsx
+++ b/src/app/(authenticated)/specialist/evaluations/results/answer/page.tsx
@@ -32,6 +32,8 @@ const RenderComponent = ({ user, evaluation, data, template }: RenderComponentPr
       return <LeapResult user={user} evaluation={evaluation} data={data as Leap} />;
     case 'sus':
     case 'sus_mf':
+    case 'sus_adaptado_mf':
+      // Reaproveitamos o SusResult porque o payload e a lógica do sus_adaptado_mf são estruturalmente idênticos (10 campos, 1 a 5)
       return <SusResult user={user} evaluation={evaluation} data={data as Sus} />;
     case 'tuq_mf':
       return <TuqResult user={user} evaluation={evaluation} data={data as TuqRespostas} />;

--- a/src/app/(authenticated)/specialist/evaluations/results/groupanswer/page.tsx
+++ b/src/app/(authenticated)/specialist/evaluations/results/groupanswer/page.tsx
@@ -58,6 +58,7 @@ const RenderComponent = ({ evaluation, answers }: RenderComponentProps) => {
             return <LeapResultMultiple evaluation={evaluation} answers={answers as LeapAnswer[]} />;
         case 'sus':
         case 'sus_mf':
+        case 'sus_adaptado_mf':
             return <SusResultMultiple evaluation={evaluation} answers={answers as SusAnswer[]}/>;
         case 'tuq_mf':
             return (

--- a/src/app/(authenticated)/user/evaluations/fill/page.tsx
+++ b/src/app/(authenticated)/user/evaluations/fill/page.tsx
@@ -7,6 +7,7 @@ import PanasForm from '@/components/form/instrument/PanasForm';
 import SamForm from '@/components/form/instrument/SamForm';
 import SusForm from '@/components/form/instrument/SusForm';
 import { SusInstrument as MfSusForm } from '@/components/form/instrument/MfSusForm';
+import { MfSusAdaptadoForm } from '@/components/form/instrument/MfSusAdaptadoForm';
 import { MfTuqForm } from '@/components/form/instrument/MfTuqForm';
 import EazForm from '@/components/form/instrument/EazForm';
 import BrumsForm from '@/components/form/instrument/BrumsForm';
@@ -37,6 +38,8 @@ const RenderComponent = ({ instrument, userId, evaluationId, identification, tem
       return <SusForm {...commonProps} identification={identification} />;
     case "sus_mf":
       return <MfSusForm {...commonProps} />;
+    case "sus_adaptado_mf":
+      return <MfSusAdaptadoForm {...commonProps} />;
     case "tuq_mf":
       return <MfTuqForm {...commonProps} />;
     case "eaz":

--- a/src/components/form/instrument/MfSusAdaptadoForm.tsx
+++ b/src/components/form/instrument/MfSusAdaptadoForm.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import Script from 'next/script';
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { saveAnswer } from '@/lib/firebase';
+import { useToast } from '@/components/ui/use-toast';
+
+interface SusAdaptadoInstrumentProps {
+    evaluationId: string;
+    userId: string;
+}
+
+// Declarar o custom element para o TypeScript
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'emoframe-mf-sus-adaptado': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        'evaluation-id'?: string;
+        'user-id'?: string;
+      };
+    }
+  }
+}
+
+export function MfSusAdaptadoForm({ evaluationId, userId }: SusAdaptadoInstrumentProps) {
+    const { push } = useRouter();
+    const { toast } = useToast();
+
+    useEffect(() => {
+        const handleMfEvent = (event: Event) => {
+            const customEvent = event as CustomEvent;
+            const { answers, score, evaluationId, userId } = customEvent.detail;
+            console.log('Dados recebidos do MF SUS Adaptado:', customEvent.detail);
+            
+            saveAnswer({ ...answers, score }, evaluationId, userId).then(() => {
+                toast({
+                    title: "Avaliação salva com sucesso!",
+                    description: "Obrigado por responder o formulário.",
+                });
+                push('/user/evaluations');
+            }).catch((err) => {
+                console.error("Erro ao salvar avaliação do MF SUS Adaptado", err);
+                toast({
+                    title: "Erro",
+                    description: "Ocorreu um erro ao salvar as respostas.",
+                    variant: "destructive"
+                });
+            });
+        };
+
+        window.addEventListener('sus-adaptado-completed', handleMfEvent);
+        return () => window.removeEventListener('sus-adaptado-completed', handleMfEvent);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    const mfUrl = process.env.NEXT_PUBLIC_MF_SUS_ADAPTADO_URL || 'http://localhost:5175/sus-adaptado-form.js';
+    const isDev = mfUrl.includes('localhost');
+
+    return (
+        <div className="sus-adaptado-wrapper">
+            {isDev ? (
+                <>
+                    <Script
+                        src="http://localhost:5175/@vite/client"
+                        strategy="lazyOnload"
+                        type="module"
+                    />
+                    <Script
+                        src="http://localhost:5175/src/main.tsx"
+                        strategy="lazyOnload"
+                        type="module"
+                    />
+                </>
+            ) : (
+                <Script
+                    src={mfUrl}
+                    strategy="lazyOnload"
+                    type="module"
+                />
+            )}
+
+            <emoframe-mf-sus-adaptado
+                evaluation-id={evaluationId}
+                user-id={userId}
+            ></emoframe-mf-sus-adaptado>
+        </div>
+    );
+}

--- a/src/components/form/instrument/MfSusForm.tsx
+++ b/src/components/form/instrument/MfSusForm.tsx
@@ -12,6 +12,18 @@ interface SusInstrumentProps {
     userId: string;
 }
 
+// Declarar o custom element para o TypeScript
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'emoframe-mf-sus': React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement> & {
+        'evaluation-id'?: string;
+        'user-id'?: string;
+      };
+    }
+  }
+}
+
 export function SusInstrument({ evaluationId, userId }: SusInstrumentProps) {
     const { push } = useRouter();
     const { toast } = useToast();
@@ -43,22 +55,31 @@ export function SusInstrument({ evaluationId, userId }: SusInstrumentProps) {
         return () => window.removeEventListener('sus-completed', handleMfEvent);
     }, []);
 
+    const mfUrl = process.env.NEXT_PUBLIC_MF_SUS_URL || 'http://localhost:5173/sus-form.js';
+    const isDev = mfUrl.includes('localhost');
+
     return (
         <div className="sus-wrapper">
-            {/* 
-                Em desenvolvimento local, consumimos diretamente o servidor do Vite (porta 5173).
-                Em produção, este script deve apontar para o bundle gerado (ex: dist/sus-form.js).
-            */}
-            <Script
-                src="http://localhost:5173/@vite/client"
-                strategy="lazyOnload"
-                type="module"
-            />
-            <Script
-                src="http://localhost:5173/src/main.tsx"
-                strategy="lazyOnload"
-                type="module"
-            />
+            {isDev ? (
+                <>
+                    <Script
+                        src="http://localhost:5173/@vite/client"
+                        strategy="lazyOnload"
+                        type="module"
+                    />
+                    <Script
+                        src="http://localhost:5173/src/main.tsx"
+                        strategy="lazyOnload"
+                        type="module"
+                    />
+                </>
+            ) : (
+                <Script
+                    src={mfUrl}
+                    strategy="lazyOnload"
+                    type="module"
+                />
+            )}
 
             {/* A nossa tag customizada registrada pelo MF */}
             <emoframe-mf-sus

--- a/src/components/form/instrument/MfSusForm.tsx
+++ b/src/components/form/instrument/MfSusForm.tsx
@@ -20,10 +20,10 @@ export function SusInstrument({ evaluationId, userId }: SusInstrumentProps) {
     useEffect(() => {
         const handleMfEvent = (event: Event) => {
             const customEvent = event as CustomEvent;
-            const { values, evaluationId, userId } = customEvent.detail;
+            const { answers, score, evaluationId, userId } = customEvent.detail;
             console.log('Dados recebidos do MF:', customEvent.detail);
-            
-            saveAnswer(values, evaluationId, userId).then(() => {
+
+            saveAnswer({ ...answers, score }, evaluationId, userId).then(() => {
                 toast({
                     title: t("submitTitle", "Avaliação salva com sucesso!"),
                     description: t("submitMessage", "Obrigado por responder o formulário."),
@@ -39,8 +39,8 @@ export function SusInstrument({ evaluationId, userId }: SusInstrumentProps) {
             });
         };
 
-        window.addEventListener('sus-form-submitted', handleMfEvent);
-        return () => window.removeEventListener('sus-form-submitted', handleMfEvent);
+        window.addEventListener('sus-completed', handleMfEvent);
+        return () => window.removeEventListener('sus-completed', handleMfEvent);
     }, []);
 
     return (

--- a/src/types/forms.tsx
+++ b/src/types/forms.tsx
@@ -439,6 +439,12 @@ export const instruments: Instruments[] = [
         description: "specialist_services_instruments:tuq_mf",
         locales: ["pt"],
     },
+    {
+        value: "sus_adaptado_mf",
+        label: "SUS Adaptado MF",
+        description: "specialist_services_instruments:sus_adaptado_mf",
+        locales: ["pt"],
+    },
 ];
 
 


### PR DESCRIPTION
## Contexto
Este Pull Request introduz a integração do terceiro instrumento do fluxo de avaliação de usabilidade: o **SUS Adaptado** (System Usability Scale com a tradução validada por Martins et al., 2015).

A implementação segue a estratégia arquitetural de "Cascata" adotada no Emoframe (baseando-se nas features anteriores do SUS tradicional e do TUQ) e utiliza o padrão de **Micro Frontends (MFE)** encapsulados via Web Components. O objetivo é permitir que pesquisadores tenham uma versão em português do SUS academicamente validada para uso em suas coletas de dados, de forma desacoplada do monólito do Next.js.

## O que foi feito 
* **Criação do Wrapper React (`MfSusAdaptadoForm.tsx`):** Desenvolvido o componente ponte que embute a tag customizada `<emoframe-mf-sus-adaptado>` dentro do Next.js.
* **Injeção Dinâmica de Scripts:** Lógica condicional implementada via `next/script` para carregar o *bundle* local do Vite (porta `5175`) em ambiente de desenvolvimento (`isDev`) ou a URL de produção através da variável de ambiente `NEXT_PUBLIC_MF_SUS_ADAPTADO_URL`.
* **Comunicação Orientada a Eventos:** O wrapper escuta ativamente o evento customizado `sus-adaptado-completed` disparado pelo MFE, isolando a responsabilidade de rede do componente visual.
* **Persistência de Dados Integrada:** Ao receber o payload do evento (respostas + score), o wrapper repassa os dados para o ecossistema central do Emoframe, utilizando a função `saveAnswer` para persistência no Firebase/Firestore.
* **Gestão de UX (Toast & Redirect):** Adicionado feedback em tempo real para o usuário (via `useToast`) em caso de sucesso ou falha, seguido de redirecionamento para o dashboard de avaliações após submissão bem-sucedida.

## Dependências e Relacionamento de Branches
* **Branch Base deste PR:** `feat/implementa-mf-tuq`
* Este PR fecha o escopo de implementação técnica dos três instrumentos iniciais do projeto.
* O código fonte e as regras de negócio de cálculo do SUS Adaptado rodam de forma autônoma no repositório satélite recém-criado: `emoframe-mf-sus-adaptado`.

## Cenário de Testes (Como Validar)

Para testar essa branch localmente, segui o roteiro abaixo:

**1. Preparação dos Repositórios**
* Puxe as alterações do Emoframe: `git pull origin feat/implementa-mf-sus-adaptado`
* No repositório do MFE do SUS Adaptado (`emoframe-mf-sus-adaptado`), instale as dependências com `npm install` e rode o servidor de desenvolvimento: `npm run dev` (certifique-se de que está rodando na porta `5175`).

**2. Teste de Interface e Injeção**
* Inicie o Emoframe: `npm run dev`.
* Logue como `Specialist`, crie um novo Projeto e configure uma Avaliação utilizando o instrumento **SUS Adaptado**.

**3. Teste de Submissão de Dados**
* Abra o link em uma aba anônima (atuando como o perfil `User`).
* A interface do SUS Adaptado deve renderizar perfeitamente.
* Preencha as 10 perguntas do instrumento.
* Clique no botão de enviar.